### PR TITLE
Use File.seperator instead of platform specific path seperators

### DIFF
--- a/src/sporemodder/GameManager.java
+++ b/src/sporemodder/GameManager.java
@@ -53,7 +53,7 @@ public class GameManager extends AbstractManager {
 			"HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Electronic Arts\\SPORE(TM) Creepy & Cute Parts Pack",
 			"HKEY_LOCAL_MACHINE\\SOFTWARE\\Electronic Arts\\SPORE(TM) Creepy & Cute Parts Pack" };
 	
-	public static final String SPORE_SPOREBIN = "Sporebin";
+	public static final String SPORE_SPOREBIN = "SporeBin";
 	public static final String GA_SPOREBIN = "SporebinEP1";
 	
 	private static final String PROPERTY_commandLineArgs = "gameCommandLine";  
@@ -440,8 +440,8 @@ public class GameManager extends AbstractManager {
 
 	// This method returns the path to the folder that contains the executable
 	private static String moveToSporebin(String folderName, String path, boolean bRecursive) {
-		if (!path.endsWith("\\")) {
-			path += "\\";
+		if (!path.endsWith(File.separator)) {
+			path += File.separator;
 		}
 
 		if (new File(path, "SporeApp.exe").exists()) {
@@ -449,7 +449,7 @@ public class GameManager extends AbstractManager {
 		}
 
 		if (new File(path, folderName).exists()) {
-			return path + folderName + "\\";
+			return path + folderName + File.separator;
 		}
 
 		if (bRecursive) {

--- a/src/sporemodder/file/dbpf/DebugInformation.java
+++ b/src/sporemodder/file/dbpf/DebugInformation.java
@@ -19,6 +19,7 @@
 package sporemodder.file.dbpf;
 
 import java.io.IOException;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +49,7 @@ public class DebugInformation {
 	}
 	
 	public void addFile(String folderName, String fileName, ResourceKey name) {
-		fileNames.add(folderName + '\\' + fileName);
+		fileNames.add(folderName + File.separator + fileName);
 		fileKeys.add(name);
 	}
 	


### PR DESCRIPTION
This patch fixes the ability to select the Spore game installation on Linux.

before this patch it'd say the following:
![image](https://github.com/emd4600/SporeModder-FX/assets/18737914/5a7a4208-1135-4fa3-be54-e5c83a35fec8)